### PR TITLE
Override palette with custom_colors

### DIFF
--- a/src/Concerns/Palette.php
+++ b/src/Concerns/Palette.php
@@ -10,7 +10,7 @@ trait Palette
      * @param  string $color
      * @return string[]
      */
-    public function palette($color = null)
+    public function palette($color = null, $custom_colors = [])
     {
         $colors = [];
         $themeJson = [];
@@ -31,6 +31,10 @@ trait Palette
             return $color ?: $colors;
         }
 
+        if (! empty($custom_colors)) {
+            $palette = $this->sanitize_custom_colors($custom_colors);
+        }
+
         foreach ($palette as $value) {
             if (empty($value['slug'])) {
                 continue;
@@ -47,5 +51,20 @@ trait Palette
         return ! empty($color) ? (
             $colors[$color] ?? null
         ) : $colors;
+    }
+
+    public function sanitize_custom_colors($customColors = [])
+    {
+        if (! is_array($customColors)) {
+            return [];
+        }
+
+        return array_map(function ($color) {
+            if (empty($color['slug'])) {
+                $color['slug'] = sanitize_title($color['name']);
+            }
+
+            return $color;
+        }, $customColors);
     }
 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -63,13 +63,7 @@ class Field extends \acf_field
         }
 
         if (! empty($customColors = $field['custom_colors']) && is_array($customColors)) {
-            $palette = array_map(function ($color) {
-                if (empty($color['slug'])) {
-                    $color['slug'] = sanitize_title($color['name']);
-                }
-
-                return $color;
-            }, $customColors);
+            $palette = $this->sanitize_custom_colors($customColors);
         }
 
         if (empty($palette)) {
@@ -275,7 +269,7 @@ class Field extends \acf_field
         $format = $field['return_format'] ?? $this->defaults['return_format'];
 
         if (! empty($value) && is_string($value)) {
-            $value = $this->palette($value);
+            $value = $this->palette($value, $field['custom_colors']);
         }
 
         return $format === 'array' ? $value : ($value[$format] ?? $value);
@@ -296,7 +290,7 @@ class Field extends \acf_field
         if (
             $valid &&
             ! empty($value) &&
-            empty($this->palette($value))
+            empty($this->palette($value, $field['custom_colors']))
         ) {
             return __('The current color does not exist in the editor palette.', 'acf-editor-palette');
         }
@@ -320,7 +314,7 @@ class Field extends \acf_field
 
         $value = is_string($value) ? $value : $value['slug'];
 
-        return $this->palette($value);
+        return $this->palette($value, $field['custom_colors']);
     }
 
     /**


### PR DESCRIPTION
We need `$this->palette` to have our custom_color array so all the Field methods (`validate_value`, `format_value ` & `update_value `) work as expected.